### PR TITLE
Convert PropTypes to use new package

### DIFF
--- a/src/utils/mixpanelShape.js
+++ b/src/utils/mixpanelShape.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react'
+import PropTypes from 'prop-types'
 
 
 export default PropTypes.shape({


### PR DESCRIPTION
React.PropTypes is deprecated