### PR TITLE
export all context object to be able to use hooks

### DIFF
--- a/src/MixpanelContext.js
+++ b/src/MixpanelContext.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const {Provider, Consumer} = React.createContext();
+export const MixpanelContext = React.createContext();
 
-Provider.propTypes = {
+MixpanelContext.Provider.propTypes = {
 	value: PropTypes.shape({
 		init: PropTypes.func.isRequired,
 		track: PropTypes.func.isRequired,
@@ -12,9 +12,9 @@ Provider.propTypes = {
 
 export class MixpanelProvider extends React.Component {
 	render() {
-		return <Provider value={this.props.mixpanel}>
+		return <MixpanelContext.Provider value={this.props.mixpanel}>
 			{this.props.children}
-		</Provider>
+		</MixpanelContext.Provider>
 	}
 }
 
@@ -30,4 +30,4 @@ MixpanelProvider.propTypes = {
 	mixpanel: mixpanelShape
 };
 
-export const MixpanelConsumer = Consumer;
+export const MixpanelConsumer = MixpanelContext.Consumer;


### PR DESCRIPTION
Hi 👋 ,
Currently you can't use useContext hook with react-mixpanel as the hook is requiring to give the whole context object.

Let's export the whole context if needed, and let the rest in place to avoid breaking changes ;-)
