### PR TITLE
fix(exports): adds MixpanelContext to exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export {MixpanelProvider, MixpanelConsumer} from './MixpanelContext'
+export {MixpanelProvider, MixpanelConsumer,MixpanelContext} from './MixpanelContext'


### PR DESCRIPTION
## Description
Was trying to use this library with the new `useContext` hook when I tried
```javascript
import {MixpanelContext} from 'react-mixpanel'
```
was getting undefined back.  After looking at it saw that the context was exported in the `src/MixPanelContext.js` file but not the index. So to import had to 
```javascript 
import {MixpanelContext}from 'react-mixpanel/lib/MixpanelContext'
```
which wasn't as intuitive this PR just adds to index.js so you can import with 
```javascript
import {MixpanelContext} from 'react-mixpanel'
```
