### PR TITLE
Remove slash from opening tag in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ReactDOM.render(
 ```
 const App = () => 
     <Foo>
-        <MixpanelConsumer/>
+        <MixpanelConsumer>
             {mixpanel => ...}
         </MixpanelConsumer>
     </Foo>;
@@ -52,7 +52,7 @@ class INeedMixpanel extends React.Component {
 
 const App = () => 
     <Foo>
-        <MixpanelConsumer/>
+        <MixpanelConsumer>
             {mixpanel => <INeedMixpanel mixpanel={mixpanel}/>}
         </MixpanelConsumer>
     </Foo>;


### PR DESCRIPTION
In the README code samples, this removes trailing slashes from opening
tags of components that have children.

I compared against the MixpanelConsumer in [the example
app](https://github.com/neciu/react-mixpanel/blob/master/examples/app/src/index.js)
to make sure this was not some React convention I had never heard of.